### PR TITLE
Migrate the project to Java 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ requestData.setCallContext(ctx);
 client.executeSynchronous(requestData);
 ```
 
-Заб.: Препоръчително е да се използват <a href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files</a>
+Заб.: Ако използвате Java 8 е препоръчително да се използват <a href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files</a>
 
 Заб.: Не са генерирани всички класове за всички регистри. Това може да стане чрез следната команда, изпълнена в директория на съответните схеми (в директорията schemas)
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>bg.government.regixclient</groupId>
     <artifactId>regixclient</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>12</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -20,6 +20,21 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.jws</groupId>
+            <artifactId>javax.jws-api</artifactId>
+            <version>1.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
                 <version>3.1</version>
                 <configuration>
                     <source>${java.version}</source>
-                    <target>${java.verison}</target>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/bg/government/regixclient/RegixClient.java
+++ b/src/main/java/bg/government/regixclient/RegixClient.java
@@ -1,13 +1,8 @@
 package bg.government.regixclient;
 
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.security.KeyStore;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
+import bg.government.regixclient.ServiceRequestData.Argument;
+import bg.government.regixclient.requests.Operation;
+import com.sun.xml.ws.developer.JAXWSProperties;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
@@ -18,11 +13,14 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.soap.AddressingFeature;
-
-import bg.government.regixclient.ServiceRequestData.Argument;
-import bg.government.regixclient.requests.Operation;
-
-import com.sun.xml.internal.ws.developer.JAXWSProperties;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 /**
  * A client for Regix operations. Consumers can request data from registers through regix by using an instance of this

--- a/src/main/java/bg/government/regixclient/RegixClientDemo.java
+++ b/src/main/java/bg/government/regixclient/RegixClientDemo.java
@@ -1,9 +1,10 @@
 package bg.government.regixclient;
 
-import java.lang.reflect.Field;
-
 import bg.government.regixclient.requests.grao.GraoOperation;
 import bg.government.regixclient.requests.grao.pna.PermanentAddressRequest;
+
+import java.lang.reflect.Field;
+import java.security.Security;
 
 public class RegixClientDemo {
 
@@ -30,7 +31,12 @@ public class RegixClientDemo {
 
     @SuppressWarnings("unused")
     private static void setupTLS() throws Exception {
-        // enable strong security
+        // strong security is enabled by default for Java 12
+
+        // enable strong security BEFORE Java 12
+        Security.setProperty("crypto.policy", "unlimited");
+
+        // enable strong security BEFORE Java 9
         Field field = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");
         field.setAccessible(true);
         field.set(null, java.lang.Boolean.FALSE);


### PR DESCRIPTION
Migrate the project to Java 12  …
 * JAX-WS is now a separate project: https://javaee.github.io/metro-jax-ws/
 * JCE is included and set to unlimited by default
 * RegixClient was using ```import com.sun.xml.internal.ws.developer.JAXWSProperties;``` instead of ```import com.sun.xml.ws.developer.JAXWSProperties;```
